### PR TITLE
Removed Unnecessary Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
     "url": "https://github.com/barbarbar338/eris-collector/issues"
   },
   "bundledependencies": false,
-  "dependencies": {
-    "events": "^3.1.0"
-  },
   "deprecated": false,
   "description": "Create reaction and message collector easily with Eris",
   "homepage": "https://github.com/barbarbar338/eris-collector#readme",


### PR DESCRIPTION
Node.js has event already. You need not to add it as an dependency.